### PR TITLE
Update stylesheet.css

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -186,6 +186,10 @@ ul.cmds li:before {
 				". . . . . . . . . . . . . . . . . . . . ";
 }
 
+ul.cmds li {
+	clear:			right;
+}
+
 ul.cmds a {
 	padding-right:		0.33em;
 	background:		#dff;


### PR DESCRIPTION
Depending on the user font, the list of commands can go off by one like:

```
fsm_reencode . . . . . .  recoding finite state machines
greenpak4_dffinv . . . . . . . . . . . . . . . . . . . .
help . . . . . merge greenpak4 inverters and DFF/latches
hierarchy  . . . . . . . . . . . . display help messages
```

adding "clear: right" to the &lt;li/&gt;s fixes that